### PR TITLE
Fix PATCH user roles not updated bug

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -234,6 +234,7 @@ class UserResource():
 
             # Update database
             roles = [await RoleModel.get(id=role_id) for role_id in role_ids]
+            await user_data.roles.clear()
             await user_data.roles.add(*roles)
 
             # Update response


### PR DESCRIPTION
## What?
UserResourceのPATCHメソッドで，ユーザのロールを追加する前に一度全部消すようにした

## Why?
ユーザのロールをアップデートする際に，削除したロールが残ってしまう（追加は問題ない）バグがあった

## See also [Optional]
- Issue #15 

## Screenshot or video [Optional]
