### PR TITLE
[WIP] Subdivide actions

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -20,9 +20,20 @@ TORTOISE_ORM = {
 
 class ActionType(Enum):
     """List of actions."""
-    read_only_public = 'Read only public'
-    read_all = 'Read all'
-    write = 'Write'
+    # Database-related actions
+    read_databases = 'Read databases'           # Read databases
+    add_databases = 'Add databases'             # Add new databases
+    update_databases = 'Update databases'       # Update metadata of databases
+    delete_databases = 'Delete databases'       # Delete databases
+
+    # Record-related actions
+    read_records = 'Read records'               # Read records
+    add_records = 'Write records'               # Add new records
+    update_records = 'Update records'           # Update metadata of records
+    delete_records = 'Delete records'           # Delete records
+
+    # Metadata-related actions
+    read_private_keys = 'Read private keys in metadata'     # Read private keys
 
     def describe(self) -> Dict[str, str]:
         """Returns action as a dict object.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -44,21 +44,34 @@ async def setup_testdb(auth0_existing_userid):
         name='role1',
         permissions=[{
             'databases': ['database1', 'database2'],
-            'action_ids': [ActionType.read_all.name, ActionType.write.name],
+            'action_ids': [
+                ActionType.read_records.name,
+                ActionType.add_records.name,
+                ActionType.update_records.name,
+                ActionType.delete_records.name,
+                ActionType.read_private_keys.name,
+            ],
         }]
     )
     role2 = await RoleModel.create(
         name='role2',
         permissions=[{
             'databases': ['database1', 'database2'],
-            'action_ids': [ActionType.read_only_public.name, ActionType.write.name],
+            'action_ids': [
+                ActionType.read_records.name,
+                ActionType.add_records.name,
+                ActionType.update_records.name,
+                ActionType.delete_records.name,
+            ],
         }]
     )
     role3 = await RoleModel.create(
         name='role3',
         permissions=[{
             'databases': ['database1', 'database2'],
-            'action_ids': [ActionType.read_only_public.name],
+            'action_ids': [
+                ActionType.read_records.name,
+            ],
         }]
     )
     role4 = await RoleModel.create(

--- a/test/test_api/test_actions.py
+++ b/test/test_api/test_actions.py
@@ -13,7 +13,7 @@ class TestActionsResource:
 
 class TestActionResource:
     def test_get_action_200(self, api):
-        r = api.requests.get(url=api.url_for(server.ActionResource, action_id='write'))
+        r = api.requests.get(url=api.url_for(server.ActionResource, action_id='add_records'))
         assert r.status_code == 200
         data = json.loads(r.text)
         assert 'action_id' in data.keys()

--- a/test/test_api/test_is_permitted.py
+++ b/test/test_api/test_is_permitted.py
@@ -8,7 +8,7 @@ def test_is_permitted_200(setup_testdb, api):
     r = api.requests.get(
         url=api.url_for(server.IsPermittedResource),
         params={
-            'action_id': ActionType.read_all.name,
+            'action_id': ActionType.read_records.name,
             'database_id': 'database1',
             'user_id': setup_testdb['existing_user_id'],
         },
@@ -20,7 +20,7 @@ def test_is_permitted_200(setup_testdb, api):
     r = api.requests.get(
         url=api.url_for(server.IsPermittedResource),
         params={
-            'action_id': ActionType.read_all.name,
+            'action_id': ActionType.read_records.name,
             'database_id': 'database10',
             'user_id': setup_testdb['existing_user_id'],
         },
@@ -57,7 +57,7 @@ def test_is_permitted_no_database_id_400(setup_testdb, api):
     r = api.requests.get(
         url=api.url_for(server.IsPermittedResource),
         params={
-            'action_id': ActionType.read_all.name,
+            'action_id': ActionType.read_records.name,
             'user_id': setup_testdb['existing_user_id'],
         },
     )
@@ -68,7 +68,7 @@ def test_is_permitted_invalid_token_403(api):
     r = api.requests.get(
         url=api.url_for(server.IsPermittedResource),
         params={
-            'action_id': ActionType.read_all.name,
+            'action_id': ActionType.read_records.name,
             'database_id': 'database1',
         },
         headers={'authorization': 'Bearer invalid_token'},

--- a/test/test_api/test_roles.py
+++ b/test/test_api/test_roles.py
@@ -140,7 +140,7 @@ class TestRolesResource:
                 'permissions': [
                     {
                         'databases': ['database1', 'database2'],
-                        'action_ids': [ActionType.read_all.name, ActionType.write.name],
+                        'action_ids': [ActionType.read_records.name, ActionType.add_records.name],
                     },
                 ],
             },
@@ -248,7 +248,7 @@ class TestRoleResource:
                 'permissions': [
                     {
                         'databases': ['database1', 'database2'],
-                        'action_ids': [ActionType.read_all.name],
+                        'action_ids': [ActionType.read_records.name],
                     },
                 ],
             },

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -44,14 +44,22 @@ async def setup_db_for_test_permission_check():
         name='role1',
         permissions=[{
             'databases': ['database1'],
-            'action_ids': [ActionType.read_all.name, ActionType.write.name],
+            'action_ids': [
+                ActionType.read_records.name,
+                ActionType.add_records.name,
+                ActionType.update_records.name,
+                ActionType.delete_records.name,
+                ActionType.read_private_keys.name,
+            ],
         }]
     )
     role2 = await RoleModel.create(
         name='role2',
         permissions=[{
             'databases': ['testpostfix*', '*testprefix', 'test?single'],
-            'action_ids': [ActionType.read_only_public.name],
+            'action_ids': [
+                ActionType.read_records.name,
+            ],
         }]
     )
     from api.models import UserModel
@@ -68,48 +76,48 @@ async def setup_db_for_test_permission_check():
 async def test_is_user_permitted_action(setup_db_for_test_permission_check):
     assert await is_user_permitted_action(
         setup_db_for_test_permission_check['user_id'],
-        ActionType.read_only_public,
+        ActionType.read_records,
         'testpostfix123123',
     ) is True
 
     assert await is_user_permitted_action(
         setup_db_for_test_permission_check['user_id'],
-        ActionType.read_only_public,
+        ActionType.read_records,
         '123123testprefix',
     ) is True
 
     assert await is_user_permitted_action(
         setup_db_for_test_permission_check['user_id'],
-        ActionType.read_only_public,
+        ActionType.read_records,
         'test1single',
     ) is True
 
     assert await is_user_permitted_action(
         setup_db_for_test_permission_check['user_id'],
-        ActionType.read_only_public,
+        ActionType.read_records,
         'testsingle',
     ) is False
 
     assert await is_user_permitted_action(
         setup_db_for_test_permission_check['user_id'],
-        ActionType.read_only_public,
+        ActionType.read_records,
         'should_be_false_database',
     ) is False
 
     assert await is_user_permitted_action(
         setup_db_for_test_permission_check['user_id'],
-        ActionType.read_only_public,
-        'database1',
+        ActionType.read_private_keys,
+        'testpostfix123123',
     ) is False
 
     assert await is_user_permitted_action(
         setup_db_for_test_permission_check['user_id'],
-        ActionType.read_all,
+        ActionType.read_private_keys,
         'database1',
     ) is True
 
     assert await is_user_permitted_action(
         setup_db_for_test_permission_check['user_id'],
-        ActionType.write,
+        ActionType.add_records,
         'database1',
     ) is True


### PR DESCRIPTION
## What?
Action の種類を以下のように細分化

- `read_only_public` : メタ情報のパブリックなキーのみが見れる
- `read_all` : メタ情報のプライベートなキーも見れる
- `write_all` : record の追加・更新・削除ができる

↓

- `read_databases` : データベースが見れる
- `add_databases`: 新しいデータベースを追加できる
- `update_databases` : データベースを更新できる
- `delete_databases` : データベースを削除できる
- `read_records` : レコードが見れる
- `add_records`: レコードを追加できる
- `update_records`: レコードのメタ情報を更新できる
- `delete_records`: レコードを削除できる
- `read_private_keys`: レコードのメタ情報のプライベートなキーを見れる

## Why?
現状の action だと細かい権限管理ができないから

## See also [Optional]
https://www.notion.so/humandatawarelab/api-permission-manager-Action-8bedb08fc7f8430c9b62b02feb7e8454
