### PR TITLE
[WIP] Subdivide actions

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -20,9 +20,20 @@ TORTOISE_ORM = {
 
 class ActionType(Enum):
     """List of actions."""
-    read_only_public = 'Read only public'
-    read_all = 'Read all'
-    write = 'Write'
+    # Database-related actions
+    read_databases = 'Read databases'           # Read databases
+    add_databases = 'Add databases'             # Add new databases
+    update_databases = 'Update databases'       # Update metadata of databases
+    delete_databases = 'Delete databases'       # Delete databases
+
+    # Metadata-related actions
+    read_metadata = 'Read metadata'               # Read metadata
+    add_metadata = 'Write metadata'               # Add new metadata
+    update_metadata = 'Update metadata'           # Update metadata of metadata
+    delete_metadata = 'Delete metadata'           # Delete metadata
+
+    # Metadata-related actions
+    read_private_keys = 'Read private keys in metadata'     # Read private keys
 
     def describe(self) -> Dict[str, str]:
         """Returns action as a dict object.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -44,21 +44,34 @@ async def setup_testdb(auth0_existing_userid):
         name='role1',
         permissions=[{
             'databases': ['database1', 'database2'],
-            'action_ids': [ActionType.read_all.name, ActionType.write.name],
+            'action_ids': [
+                ActionType.read_metadata.name,
+                ActionType.add_metadata.name,
+                ActionType.update_metadata.name,
+                ActionType.delete_metadata.name,
+                ActionType.read_private_keys.name,
+            ],
         }]
     )
     role2 = await RoleModel.create(
         name='role2',
         permissions=[{
             'databases': ['database1', 'database2'],
-            'action_ids': [ActionType.read_only_public.name, ActionType.write.name],
+            'action_ids': [
+                ActionType.read_metadata.name,
+                ActionType.add_metadata.name,
+                ActionType.update_metadata.name,
+                ActionType.delete_metadata.name,
+            ],
         }]
     )
     role3 = await RoleModel.create(
         name='role3',
         permissions=[{
             'databases': ['database1', 'database2'],
-            'action_ids': [ActionType.read_only_public.name],
+            'action_ids': [
+                ActionType.read_metadata.name,
+            ],
         }]
     )
     role4 = await RoleModel.create(

--- a/test/test_api/test_actions.py
+++ b/test/test_api/test_actions.py
@@ -13,7 +13,7 @@ class TestActionsResource:
 
 class TestActionResource:
     def test_get_action_200(self, api):
-        r = api.requests.get(url=api.url_for(server.ActionResource, action_id='write'))
+        r = api.requests.get(url=api.url_for(server.ActionResource, action_id='add_metadata'))
         assert r.status_code == 200
         data = json.loads(r.text)
         assert 'action_id' in data.keys()

--- a/test/test_api/test_permitted_actions.py
+++ b/test/test_api/test_permitted_actions.py
@@ -16,7 +16,13 @@ def test_get_permitted_actions(setup_testdb, api):
     )
     assert r.status_code == 200
     data = json.loads(r.text)
-    diff = set(data) ^ set(('write', 'read_all', 'read_only_public'))
+    diff = set(data) ^ {
+        ActionType.read_metadata.name,
+        ActionType.add_metadata.name,
+        ActionType.update_metadata.name,
+        ActionType.delete_metadata.name,
+        ActionType.read_private_keys.name,
+    }
     assert not diff
 
 
@@ -39,7 +45,7 @@ def test_permitted_actions_no_database_id_400(setup_testdb, api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionsResource,
-            action_id=ActionType.read_all.name,
+            action_id=ActionType.read_metadata.name,
         ),
         params={
             'user_id': setup_testdb['existing_user_id'],
@@ -52,7 +58,7 @@ def test_permitted_actions_invalid_token_403(api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionsResource,
-            action_id=ActionType.read_all.name,
+            action_id=ActionType.read_metadata.name,
         ),
         params={
             'database_id': 'database1',
@@ -66,7 +72,7 @@ def test_is_permitted_200(setup_testdb, api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionResource,
-            action_id=ActionType.read_all.name,
+            action_id=ActionType.read_metadata.name,
         ),
         params={
             'database_id': 'database1',
@@ -80,7 +86,7 @@ def test_is_permitted_200(setup_testdb, api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionResource,
-            action_id=ActionType.read_all.name,
+            action_id=ActionType.read_metadata.name,
         ),
         params={
             'database_id': 'database10',
@@ -96,7 +102,7 @@ def test_is_permitted_no_database_id_400(setup_testdb, api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionResource,
-            action_id=ActionType.read_all.name,
+            action_id=ActionType.read_metadata.name,
         ),
         params={
             'user_id': setup_testdb['existing_user_id'],
@@ -109,7 +115,7 @@ def test_is_permitted_invalid_token_403(api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionResource,
-            action_id=ActionType.read_all.name,
+            action_id=ActionType.read_metadata.name,
         ),
         params={
             'database_id': 'database1',

--- a/test/test_api/test_roles.py
+++ b/test/test_api/test_roles.py
@@ -140,7 +140,7 @@ class TestRolesResource:
                 'permissions': [
                     {
                         'databases': ['database1', 'database2'],
-                        'action_ids': [ActionType.read_all.name, ActionType.write.name],
+                        'action_ids': [ActionType.read_metadata.name, ActionType.add_metadata.name],
                     },
                 ],
             },
@@ -248,7 +248,7 @@ class TestRoleResource:
                 'permissions': [
                     {
                         'databases': ['database1', 'database2'],
-                        'action_ids': [ActionType.read_all.name],
+                        'action_ids': [ActionType.read_metadata.name],
                     },
                 ],
             },

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -18,14 +18,25 @@ async def setup_db_for_test_permission_check():
         name='role1',
         permissions=[{
             'databases': ['database1'],
-            'action_ids': [ActionType.read_all.name, ActionType.write.name],
+            'action_ids': [
+                ActionType.read_metadata.name,
+                ActionType.add_metadata.name,
+                ActionType.update_metadata.name,
+                ActionType.delete_metadata.name,
+                ActionType.read_private_keys.name,
+            ],
         }]
     )
     role2 = await RoleModel.create(
         name='role2',
         permissions=[{
             'databases': ['testpostfix*', '*testprefix', 'test?single'],
-            'action_ids': [ActionType.read_only_public.name],
+            'action_ids': [
+                ActionType.read_metadata.name,
+                ActionType.add_metadata.name,
+                ActionType.update_metadata.name,
+                ActionType.delete_metadata.name,
+            ],
         }]
     )
     from api.models import UserModel
@@ -70,42 +81,42 @@ class TestUserModel(test.TestCase):
 async def test_is_user_permitted_action(setup_db_for_test_permission_check):
     user = await UserModel.get(id=setup_db_for_test_permission_check['user_id'])
     assert await user.is_user_permitted_action(
-        ActionType.read_only_public,
+        ActionType.read_metadata,
         'testpostfix123123',
     ) is True
 
     assert await user.is_user_permitted_action(
-        ActionType.read_only_public,
+        ActionType.read_metadata,
         '123123testprefix',
     ) is True
 
     assert await user.is_user_permitted_action(
-        ActionType.read_only_public,
+        ActionType.read_metadata,
         'test1single',
     ) is True
 
     assert await user.is_user_permitted_action(
-        ActionType.read_only_public,
+        ActionType.read_metadata,
         'testsingle',
     ) is False
 
     assert await user.is_user_permitted_action(
-        ActionType.read_only_public,
+        ActionType.read_metadata,
         'should_be_false_database',
     ) is False
 
     assert await user.is_user_permitted_action(
-        ActionType.read_only_public,
-        'database1',
+        ActionType.read_private_keys,
+        'testpostfix123123',
     ) is False
 
     assert await user.is_user_permitted_action(
-        ActionType.read_all,
+        ActionType.read_private_keys,
         'database1',
     ) is True
 
     assert await user.is_user_permitted_action(
-        ActionType.write,
+        ActionType.add_metadata,
         'database1',
     ) is True
 


### PR DESCRIPTION
## What?
Action の種類を以下のように細分化

- `read_only_public` : メタ情報のパブリックなキーのみが見れる
- `read_all` : メタ情報のプライベートなキーも見れる
- `write_all` : record の追加・更新・削除ができる

↓

- `read_databases` : データベースが見れる
- `add_databases`: 新しいデータベースを追加できる
- `update_databases` : データベースを更新できる
- `delete_databases` : データベースを削除できる
- `read_metadata` : メタ情報が見れる
- `add_metadata`: メタ情報を追加できる
- `update_metadata`: メタ情報を更新できる
- `delete_metadata`: メタ情報を削除できる
- `read_private_keys`: メタ情報のプライベートなキーを見れる

## Why?
現状の action だと細かい権限管理ができないから

## See also [Optional]
https://www.notion.so/humandatawarelab/api-permission-manager-Action-8bedb08fc7f8430c9b62b02feb7e8454
https://github.com/dataware-tools/api-permission-manager/pull/23