### PR TITLE
Hierarchical actions

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -55,7 +55,6 @@ class UserModel(Model):
         """Returns if the user has permission for the action on the database.
 
         Args:
-            user_id (str)
             action (ActionType)
             database_id (str)
 
@@ -63,25 +62,13 @@ class UserModel(Model):
             (bool)
 
         """
-        # Get roles for user
-        await self.fetch_related('roles')
-        roles = self.roles
+        # Get permitted-actions
+        permitted_actions = await self.get_permitted_actions(database_id)
 
-        # Return false if no roles
-        if not roles:
-            return False
-
-        # TODO: Make it faster by memo
-        for role in roles:
-            for permission in role.permissions:
-                database_patterns = permission['databases']
-                # Check if there's match in database patterns
-                database_match: bool = match_exist_in_databases(database_id, database_patterns)
-                if not database_match:
-                    continue
-                # Check if action_ids contains specified action
-                if action.name in permission['action_ids']:
-                    return True
+        # Look over the permitted-actions
+        for permitted_action in permitted_actions:
+            if action.name.startswith(permitted_action.name):
+                return True
 
         return False
 

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, EnumMeta
 from typing import Dict, List
 
 PAGINATION = {
@@ -18,22 +18,34 @@ TORTOISE_ORM = {
 }
 
 
-class ActionType(Enum):
+class ActionTypeMeta(EnumMeta):
+    """Metaclass of ActionType."""
+
+    def __new__(mcs, cls, bases, classdict):
+        """Set actions."""
+
+        # Database-related actions
+        classdict['databases'] = 'Admin databases'
+        classdict['databases:read'] = 'Read databases'
+        classdict['databases:write'] = 'Write databases'
+        classdict['databases:write:add'] = 'Add databases'
+        classdict['databases:write:update'] = 'Update databases'
+        classdict['databases:write:delete'] = 'Delete databases'
+
+        # Metadata-related actions
+        classdict['metadata'] = 'Admin metadata'
+        classdict['metadata:read'] = 'Read metadata'
+        classdict['metadata:read:public'] = 'Read public metadata'
+        classdict['metadata:write'] = 'Write metadata'
+        classdict['metadata:write:add'] = 'Add metadata'
+        classdict['metadata:write:update'] = 'Update metadata'
+        classdict['metadata:write:delete'] = 'Delete metadata'
+
+        return super().__new__(mcs, cls, bases, classdict)
+
+
+class ActionType(Enum, metaclass=ActionTypeMeta):
     """List of actions."""
-    # Database-related actions
-    read_databases = 'Read databases'           # Read databases
-    add_databases = 'Add databases'             # Add new databases
-    update_databases = 'Update databases'       # Update metadata of databases
-    delete_databases = 'Delete databases'       # Delete databases
-
-    # Metadata-related actions
-    read_metadata = 'Read metadata'               # Read metadata
-    add_metadata = 'Write metadata'               # Add new metadata
-    update_metadata = 'Update metadata'           # Update metadata of metadata
-    delete_metadata = 'Delete metadata'           # Delete metadata
-
-    # Metadata-related actions
-    read_private_keys = 'Read private keys in metadata'     # Read private keys
 
     def describe(self) -> Dict[str, str]:
         """Returns action as a dict object.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -45,11 +45,7 @@ async def setup_testdb(auth0_existing_userid):
         permissions=[{
             'databases': ['database1', 'database2'],
             'action_ids': [
-                ActionType.read_metadata.name,
-                ActionType.add_metadata.name,
-                ActionType.update_metadata.name,
-                ActionType.delete_metadata.name,
-                ActionType.read_private_keys.name,
+                getattr(ActionType, 'metadata').name,
             ],
         }]
     )
@@ -58,10 +54,8 @@ async def setup_testdb(auth0_existing_userid):
         permissions=[{
             'databases': ['database1', 'database2'],
             'action_ids': [
-                ActionType.read_metadata.name,
-                ActionType.add_metadata.name,
-                ActionType.update_metadata.name,
-                ActionType.delete_metadata.name,
+                getattr(ActionType, 'metadata:read:public').name,
+                getattr(ActionType, 'metadata:write').name,
             ],
         }]
     )
@@ -70,7 +64,7 @@ async def setup_testdb(auth0_existing_userid):
         permissions=[{
             'databases': ['database1', 'database2'],
             'action_ids': [
-                ActionType.read_metadata.name,
+                getattr(ActionType, 'metadata:read').name,
             ],
         }]
     )

--- a/test/test_api/test_actions.py
+++ b/test/test_api/test_actions.py
@@ -13,7 +13,7 @@ class TestActionsResource:
 
 class TestActionResource:
     def test_get_action_200(self, api):
-        r = api.requests.get(url=api.url_for(server.ActionResource, action_id='add_metadata'))
+        r = api.requests.get(url=api.url_for(server.ActionResource, action_id='metadata:write'))
         assert r.status_code == 200
         data = json.loads(r.text)
         assert 'action_id' in data.keys()

--- a/test/test_api/test_permitted_actions.py
+++ b/test/test_api/test_permitted_actions.py
@@ -17,11 +17,10 @@ def test_get_permitted_actions(setup_testdb, api):
     assert r.status_code == 200
     data = json.loads(r.text)
     diff = set(data) ^ {
-        ActionType.read_metadata.name,
-        ActionType.add_metadata.name,
-        ActionType.update_metadata.name,
-        ActionType.delete_metadata.name,
-        ActionType.read_private_keys.name,
+        getattr(ActionType, 'metadata').name,
+        getattr(ActionType, 'metadata:read').name,
+        getattr(ActionType, 'metadata:read:public').name,
+        getattr(ActionType, 'metadata:write').name,
     }
     assert not diff
 
@@ -45,7 +44,7 @@ def test_permitted_actions_no_database_id_400(setup_testdb, api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionsResource,
-            action_id=ActionType.read_metadata.name,
+            action_id=getattr(ActionType, 'metadata:read').name,
         ),
         params={
             'user_id': setup_testdb['existing_user_id'],
@@ -58,7 +57,7 @@ def test_permitted_actions_invalid_token_403(api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionsResource,
-            action_id=ActionType.read_metadata.name,
+            action_id=getattr(ActionType, 'metadata:read').name,
         ),
         params={
             'database_id': 'database1',
@@ -72,7 +71,7 @@ def test_is_permitted_200(setup_testdb, api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionResource,
-            action_id=ActionType.read_metadata.name,
+            action_id=getattr(ActionType, 'metadata:read').name,
         ),
         params={
             'database_id': 'database1',
@@ -86,7 +85,7 @@ def test_is_permitted_200(setup_testdb, api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionResource,
-            action_id=ActionType.read_metadata.name,
+            action_id=getattr(ActionType, 'metadata:read').name,
         ),
         params={
             'database_id': 'database10',
@@ -102,7 +101,7 @@ def test_is_permitted_no_database_id_400(setup_testdb, api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionResource,
-            action_id=ActionType.read_metadata.name,
+            action_id=getattr(ActionType, 'metadata:read').name,
         ),
         params={
             'user_id': setup_testdb['existing_user_id'],
@@ -115,7 +114,7 @@ def test_is_permitted_invalid_token_403(api):
     r = api.requests.get(
         url=api.url_for(
             server.PermittedActionResource,
-            action_id=ActionType.read_metadata.name,
+            action_id=getattr(ActionType, 'metadata:read').name,
         ),
         params={
             'database_id': 'database1',

--- a/test/test_api/test_roles.py
+++ b/test/test_api/test_roles.py
@@ -140,7 +140,10 @@ class TestRolesResource:
                 'permissions': [
                     {
                         'databases': ['database1', 'database2'],
-                        'action_ids': [ActionType.read_metadata.name, ActionType.add_metadata.name],
+                        'action_ids': [
+                            getattr(ActionType, 'metadata:read').name,
+                            getattr(ActionType, 'metadata:write').name,
+                        ],
                     },
                 ],
             },
@@ -248,7 +251,9 @@ class TestRoleResource:
                 'permissions': [
                     {
                         'databases': ['database1', 'database2'],
-                        'action_ids': [ActionType.read_metadata.name],
+                        'action_ids': [
+                            getattr(ActionType, 'metadata:read').name
+                        ],
                     },
                 ],
             },

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -19,11 +19,7 @@ async def setup_db_for_test_permission_check():
         permissions=[{
             'databases': ['database1'],
             'action_ids': [
-                ActionType.read_metadata.name,
-                ActionType.add_metadata.name,
-                ActionType.update_metadata.name,
-                ActionType.delete_metadata.name,
-                ActionType.read_private_keys.name,
+                getattr(ActionType, 'metadata').name,
             ],
         }]
     )
@@ -32,10 +28,8 @@ async def setup_db_for_test_permission_check():
         permissions=[{
             'databases': ['testpostfix*', '*testprefix', 'test?single'],
             'action_ids': [
-                ActionType.read_metadata.name,
-                ActionType.add_metadata.name,
-                ActionType.update_metadata.name,
-                ActionType.delete_metadata.name,
+                getattr(ActionType, 'metadata:write').name,
+                getattr(ActionType, 'metadata:read:public').name,
             ],
         }]
     )
@@ -81,42 +75,42 @@ class TestUserModel(test.TestCase):
 async def test_is_user_permitted_action(setup_db_for_test_permission_check):
     user = await UserModel.get(id=setup_db_for_test_permission_check['user_id'])
     assert await user.is_user_permitted_action(
-        ActionType.read_metadata,
+        getattr(ActionType, 'metadata:read:public'),
         'testpostfix123123',
     ) is True
 
     assert await user.is_user_permitted_action(
-        ActionType.read_metadata,
+        getattr(ActionType, 'metadata:read:public'),
         '123123testprefix',
     ) is True
 
     assert await user.is_user_permitted_action(
-        ActionType.read_metadata,
+        getattr(ActionType, 'metadata:read:public'),
         'test1single',
     ) is True
 
     assert await user.is_user_permitted_action(
-        ActionType.read_metadata,
+        getattr(ActionType, 'metadata:read:public'),
         'testsingle',
     ) is False
 
     assert await user.is_user_permitted_action(
-        ActionType.read_metadata,
+        getattr(ActionType, 'metadata:read:public'),
         'should_be_false_database',
     ) is False
 
     assert await user.is_user_permitted_action(
-        ActionType.read_private_keys,
+        getattr(ActionType, 'metadata:read'),
         'testpostfix123123',
     ) is False
 
     assert await user.is_user_permitted_action(
-        ActionType.read_private_keys,
+        getattr(ActionType, 'metadata:read'),
         'database1',
     ) is True
 
     assert await user.is_user_permitted_action(
-        ActionType.add_metadata,
+        getattr(ActionType, 'metadata:write:add'),
         'database1',
     ) is True
 


### PR DESCRIPTION
## What?
Action の種類を以下のように階層的に細分化

- `read_only_public` : メタ情報のパブリックなキーのみが見れる
- `read_all` : メタ情報のプライベートなキーも見れる
- `write_all` : record の追加・更新・削除ができる

↓

- `databases` : データベースに関する全ての権限を持つ
- `databases:read`: データベースを読み込める
- `databases:write` : データベースを書き込める
- `databases:write:add` : 新しいデータベースを追加できる
- `databases:write:update` : データベースの情報を更新できる
- `databases:write:delete` : データベースを削除できる
- `metadata` : メタ情報に関する全ての権限を持つ
- `metadata:read`: メタ情報を読み込める
- `metadata:read:public`: パブリックなメタ情報を読み込める
- `metadata:write`: メタ情報を書き込める
- `metadata:write:add` : 新しいメタ情報を追加できる
- `metadata:write:update` : メタ情報を更新できる
- `metadata:write:delete` : メタ情報を削除できる

## Why?
現状の action だと細かい権限管理ができないから

## See also [Optional]
https://www.notion.so/humandatawarelab/api-permission-manager-Action-8bedb08fc7f8430c9b62b02feb7e8454
https://github.com/dataware-tools/api-permission-manager/pull/23
https://github.com/dataware-tools/api-permission-manager/pull/24