### PR TITLE
Add config for tools that does not support "exports" field

### DIFF
--- a/build_client/typescript/package.json
+++ b/build_client/typescript/package.json
@@ -17,6 +17,8 @@
       "./dist/browser/index.mjs"
     ]
   },
+  "main": "./dist/node/index.cjs",
+  "browser": "./dist/browser/index.mjs",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## What?
Add config for tools that does not support "exports" field

## Why?
Some major tools does not support "exports" field

## See also
https://github.com/dataware-tools/api-meta-store/pull/60